### PR TITLE
GDB-7072 Disable anonymous stats being sent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>GeoSpatial plugin for GraphDB</description>
 
 	<properties>
-		<graphdb.version>10.0.0-M2-TR9</graphdb.version>
+		<graphdb.version>10.0.0</graphdb.version>
 
 		<java.level>1.8</java.level>
 		<dependency.check.version>6.2.2</dependency.check.version>
@@ -44,6 +44,9 @@
 				<version>3.0.0-M3</version>
 				<configuration>
 					<argLine>${argLine} ${extraArgLine}</argLine>
+					<systemPropertyVariables>
+						<graphdb.stats.default>disabled</graphdb.stats.default>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 

--- a/src/test/java/com/ontotext/trree/plugin/geo/AbstractOrderVarIntersectionOWLIM2872.java
+++ b/src/test/java/com/ontotext/trree/plugin/geo/AbstractOrderVarIntersectionOWLIM2872.java
@@ -1,15 +1,34 @@
 package com.ontotext.trree.plugin.geo;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractOrderVarIntersectionOWLIM2872 extends SingleRepositoryFunctionalTest {
+	@ClassRule
+	public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
+
+	@BeforeClass
+	public static void setWorkDir() {
+		System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+		Config.reset();
+	}
+
+	@AfterClass
+	public static void resetWorkDir() {
+		System.clearProperty("graphdb.home.work");
+		Config.reset();
+	}
 
 	@Test
 	public void londonGeoSpatial() throws Exception {

--- a/src/test/java/com/ontotext/trree/plugin/geo/AbstractPluginGeoSpatial.java
+++ b/src/test/java/com/ontotext/trree/plugin/geo/AbstractPluginGeoSpatial.java
@@ -1,5 +1,7 @@
 package com.ontotext.trree.plugin.geo;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.IRI;
@@ -9,8 +11,7 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.*;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -38,9 +39,24 @@ public abstract class AbstractPluginGeoSpatial extends SingleRepositoryFunctiona
 	static IRI gn_Airport = SimpleValueFactory.getInstance().createIRI("http://www.geonames.org/ontology#S.AIRP");
 	static IRI gn_medical = SimpleValueFactory.getInstance().createIRI("http://www.geonames.org/ontology#S.CTRM");
 
+	@ClassRule
+	public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
+
 	@Parameters(name = "useUpdate = {0}")
 	public static List<Object[]> getParameters() {
 		return Arrays.<Object[]> asList(new Object[] { true }, new Object[] { false });
+	}
+
+	@BeforeClass
+	public static void setWorkDir() {
+		System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+		Config.reset();
+	}
+
+	@AfterClass
+	public static void resetWorkDir() {
+		System.clearProperty("graphdb.home.work");
+		Config.reset();
 	}
 
 	public AbstractPluginGeoSpatial(boolean useUpdate) {
@@ -66,7 +82,7 @@ public abstract class AbstractPluginGeoSpatial extends SingleRepositoryFunctiona
 			} else {
 				BooleanQuery q = connection.prepareBooleanQuery(QueryLanguage.SPARQL, query);
 				boolean result = q.evaluate();
-				
+
 				assertTrue(result);
 			}
 
@@ -94,19 +110,19 @@ public abstract class AbstractPluginGeoSpatial extends SingleRepositoryFunctiona
 			}
 			connection.commit();
 			connection.close();
-	
+
 			try {
 				boolean reindexed = createIndex();
 				System.out.println("createIndex " + ((reindexed) ? "success" : "failure/no datata"));
-	
+
 				getRepository().shutDown();
 				getRepository().init();
 				connection = getRepository().getConnection();
-	
+
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
-		} finally { 
+		} finally {
 			connection.close();
 		}
 	}

--- a/src/test/java/com/ontotext/trree/plugin/geo/AbstractPluginGeoSpatialCreateRandomPlaces.java
+++ b/src/test/java/com/ontotext/trree/plugin/geo/AbstractPluginGeoSpatialCreateRandomPlaces.java
@@ -1,12 +1,13 @@
 package com.ontotext.trree.plugin.geo;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.Random;
 
@@ -35,6 +36,21 @@ public abstract class AbstractPluginGeoSpatialCreateRandomPlaces extends SingleR
 			+ "     ?place omgeo:nearby('52.574472150718606' '17.008895874023438' '100') ."
 			+ "     optional {?place cidoc:P1_is_identified_by ?appellation}. "
 			+ "} ";
+
+	@ClassRule
+	public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
+
+	@BeforeClass
+	public static void setWorkDir() {
+		System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+		Config.reset();
+	}
+
+	@AfterClass
+	public static void resetWorkDir() {
+		System.clearProperty("graphdb.home.work");
+		Config.reset();
+	}
 
 	@Test
 	public void createRandomPlaces() throws Exception {
@@ -82,7 +98,7 @@ public abstract class AbstractPluginGeoSpatialCreateRandomPlaces extends SingleR
 			con.begin();
 			long id = 0;
 			int RANDOM_PLACES = 10000;
-			
+
 			if (useRemoteRepositoryManager())
 				RANDOM_PLACES=RANDOM_PLACES/10;
 

--- a/src/test/java/com/ontotext/trree/plugin/geo/AbstractSparqlGeoSpatial.java
+++ b/src/test/java/com/ontotext/trree/plugin/geo/AbstractSparqlGeoSpatial.java
@@ -1,5 +1,7 @@
 package com.ontotext.trree.plugin.geo;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import com.ontotext.test.utils.Utils;
 import org.eclipse.rdf4j.model.IRI;
@@ -10,6 +12,9 @@ import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.query.*;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -32,6 +37,21 @@ public abstract class AbstractSparqlGeoSpatial extends SingleRepositoryFunctiona
 			LAT = factory.createIRI(GEO_NAMESPACE, "lat");
 			LONG = factory.createIRI(GEO_NAMESPACE, "long");
 		}
+	}
+
+	@ClassRule
+	public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
+
+	@BeforeClass
+	public static void setWorkDir() {
+		System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+		Config.reset();
+	}
+
+	@AfterClass
+	public static void resetWorkDir() {
+		System.clearProperty("graphdb.home.work");
+		Config.reset();
 	}
 
 	@Test


### PR DESCRIPTION
Change graphDB version to 10.0.0.
Add "<graphdb.stats.default>disabled</graphdb.stats.default>" to the surefire plugin in pom.xml file.
Add temporary home.work folder to AbstractOrderVarIntersectionOWLIM2872.java, AbstractPluginGeoSpatial.java, AbstractPluginGeoSpatialCreateRandomPlaces.java and AbstractSparqlGeoSpatial.java.